### PR TITLE
declare local dockerfile in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,4 +2,7 @@ services:
   penumbra:
     image: penumbra-disclosure-cli:latest
     command: --rpc-url http://localhost:8080 api --listen-url 0.0.0.0:1337
+    build:
+      context: .
+      dockerfile: Dockerfile.penumbra
     network_mode: host


### PR DESCRIPTION
When running `docker compose up` for the first time, the specified image won't exist. One must first run `make build-penumbra-docker-release`, then `docker compose up`. Let's instead make the first-run build trigger automatically, by declaring the in-repo containerfile as part of the compose spec.